### PR TITLE
Forecast command

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -216,7 +216,6 @@ class forecast:
 
     def __init__(self):
         self.w = 0
-
     """Send a message to select between dates when the command /forecast is issued."""	
     def forecast(self,bot, update):
         try:
@@ -247,7 +246,16 @@ class forecast:
         
     """handle the reply of the button selected, sended by the funcion above"""
     def forecast_response(self, bot, update):
+        K = 273.15
         query = update.callback_query
-        query.message.reply_text("selected option: {}".format(query.data))
-        print(self.w)    
-             
+        #query.message.reply_text("selected option: {}".format(query.data))
+        msg = ["PREVISION DEL TIEMPO PARA EL DIA: {} \n".format(query.data)]
+        for i in range(self.w['cnt']):
+
+            if(query.data in self.w['list'][i]['dt_txt']):
+                date_time_str = self.w['list'][i]['dt_txt']
+                date_time = datetime.strptime(date_time_str, '%Y-%m-%d %H:%M:%S')
+                h = date_time.strftime("%H")                
+                temp = "{0:.2f}".format(self.w['list'][i]['main']['temp'] -K)
+                msg.append("hora: {} , tiempo: {} , temperatura: {} \n".format(h, self.w['list'][i]['weather'][0]['description'] , temp ))
+        query.edit_message_text(''.join(msg))

--- a/commands.py
+++ b/commands.py
@@ -213,6 +213,8 @@ def learn(bot, update):
         parse_mode=telegram.ParseMode.MARKDOWN)
 
 class forecast:
+    
+
 
     def __init__(self):
         self.w = 0
@@ -236,7 +238,7 @@ class forecast:
             keyboard_inside = []
 
             for x in days:
-                print(x)
+                #print(x)
                 keyboard_button = telegram.InlineKeyboardButton("dia: {0}".format(x), callback_data=x )
                 keyboard_inside.append(keyboard_button)
         
@@ -253,9 +255,54 @@ class forecast:
         for i in range(self.w['cnt']):
 
             if(query.data in self.w['list'][i]['dt_txt']):
-                date_time_str = self.w['list'][i]['dt_txt']
+                weather = self.w['list'][i]
+                date_time_str = weather['dt_txt']
                 date_time = datetime.strptime(date_time_str, '%Y-%m-%d %H:%M:%S')
                 h = date_time.strftime("%H")                
-                temp = "{0:.2f}".format(self.w['list'][i]['main']['temp'] -K)
-                msg.append("hora: {} , tiempo: {} , temperatura: {} \n".format(h, self.w['list'][i]['weather'][0]['description'] , temp ))
+                temp = "{0:.2f}".format(weather['main']['temp'] -K)
+                weather_id = weather['weather'][0]['id'] #for the icons
+                #print(weather_id)
+                icon = self.getEmoji(weather_id)
+                msg.append("hora: {} , tiempo: {}{} , temperatura: {} ºC \n".format(h, weather['weather'][0]['description'] , icon , temp ))
         query.edit_message_text(''.join(msg))
+
+    def getEmoji(self, weatherID):
+
+        #handling emojis: credit to: https://github.com/mustafababil/Telegram-Weather-Bot/blob/master/responseController.py#L11
+
+        thunderstorm = u'\U0001F4A8'    # Code: 200's, 900, 901, 902, 905
+        drizzle = u'\U0001F4A7'         # Code: 300's
+        rain = u'\U00002614'            # Code: 500's
+        snowflake = u'\U00002744'       # Code: 600's snowflake
+        snowman = u'\U000026C4'         # Code: 600's snowman, 903, 906
+        atmosphere = u'\U0001F301'      # Code: 700's foogy
+        clearSky = u'\U00002600'        # Code: 800 clear sky
+        fewClouds = u'\U000026C5'       # Code: 801 sun behind clouds
+        clouds = u'\U00002601'          # Code: 802-803-804 clouds general
+        hot = u'\U0001F525'             # Code: 904
+        defaultEmoji = u'\U0001F300'    # default emojis
+
+        if weatherID:
+            if str(weatherID)[0] == '2' or weatherID == 900 or weatherID==901 or weatherID==902 or weatherID==905:
+                return thunderstorm
+            elif str(weatherID)[0] == '3':
+                return drizzle
+            elif str(weatherID)[0] == '5':
+                return rain
+            elif str(weatherID)[0] == '6' or weatherID==903 or weatherID== 906:
+                return snowflake + ' ' + snowman
+            elif str(weatherID)[0] == '7':
+                return atmosphere
+            elif weatherID == 800:
+                return clearSky
+            elif weatherID == 801:
+                return fewClouds
+            elif weatherID==802 or weatherID==803 or weatherID==803:
+                return clouds
+            elif weatherID == 904:
+                 return hot
+            else:
+                 return defaultEmoji    # Default emoji
+
+        else:
+             return defaultEmoji   # Default emoji

--- a/commands.py
+++ b/commands.py
@@ -212,37 +212,42 @@ def learn(bot, update):
         ),
         parse_mode=telegram.ParseMode.MARKDOWN)
 
-def forecast(bot, update):
-    """Send a message when the command /weather is issued."""
-    try:
-        r = requests.get('{}&appid={}'.format(FORECAST_BASE_URL, WEATHER_API_KEY))
-        weather = json.loads(r.text)
-    except:
-        update.message.reply_text('Lo siento, ¡desconozco el tiempo atmosférico actual!')
-    else:
-        days = []
-        for i in range(weather['cnt']):
-            date_time_str = weather['list'][i]['dt_txt']
-            date_time = datetime.strptime(date_time_str, '%Y-%m-%d %H:%M:%S')
-            d = date_time.strftime("%d")
-            if(d not in days):
-                days.append(d)
-        keyboard = []
-        keyboard_inside = []
+class forecast:
 
-        for x in days:
-            print(x)
-            keyboard_button = telegram.InlineKeyboardButton("dia: {0}".format(x), callback_data=x )
-            keyboard_inside.append(keyboard_button)
-        
-        keyboard.append(keyboard_inside)
-        reply_markup = telegram.InlineKeyboardMarkup(keyboard)
-        update.message.reply_text("Indicame que dia quieres: {0} - {1}".format([days[i] for i in (0, -1)][0] , [days[i] for i in (0, -1)][-1]) , reply_markup=reply_markup)
-        
+    def __init__(self):
+        self.w = 0
 
-def forecast_response(bot, update):
-    query = update.callback_query
-    print(query)
-    query.message.reply_text("selected option: {}".format(query.data))
-            
+    """Send a message to select between dates when the command /forecast is issued."""	
+    def forecast(self,bot, update):
+        try:
+            r = requests.get('{}&appid={}'.format(FORECAST_BASE_URL, WEATHER_API_KEY))
+            weather = json.loads(r.text)
+            self.w = weather
+        except:
+            update.message.reply_text('Lo siento, ¡desconozco el tiempo atmosférico actual!')
+        else:
+            days = []
+            for i in range(weather['cnt']):
+                date_time_str = weather['list'][i]['dt_txt']
+                date_time = datetime.strptime(date_time_str, '%Y-%m-%d %H:%M:%S')
+                d = date_time.strftime("%d")
+                if(d not in days):
+                     days.append(d)
+            keyboard = []
+            keyboard_inside = []
+
+            for x in days:
+                print(x)
+                keyboard_button = telegram.InlineKeyboardButton("dia: {0}".format(x), callback_data=x )
+                keyboard_inside.append(keyboard_button)
+        
+            keyboard.append(keyboard_inside)
+            reply_markup = telegram.InlineKeyboardMarkup(keyboard)
+            update.message.reply_text("Indicame que dia quieres: {0} - {1}".format([days[i] for i in (0, -1)][0] , [days[i] for i in (0, -1)][-1]) , reply_markup=reply_markup)
+        
+    """handle the reply of the button selected, sended by the funcion above"""
+    def forecast_response(self, bot, update):
+        query = update.callback_query
+        query.message.reply_text("selected option: {}".format(query.data))
+        print(self.w)    
              

--- a/commands.py
+++ b/commands.py
@@ -8,9 +8,10 @@ from config import *
 from logger import logger
 
 from bs4 import BeautifulSoup
+from datetime import datetime
 
-BOTNAME = 'KoeBot'
-WEATHER_API_KEY = os.environ['WEATHER_API_KEY']
+BOTNAME = 'experiment'
+WEATHER_API_KEY = '47fc9a1a1e552b8f4b742bcf406fc830'
 
 
 # Command handlers
@@ -210,3 +211,31 @@ def learn(bot, update):
             "[Learn AI with GOOGLE](https://ai.google/education/)\n"
         ),
         parse_mode=telegram.ParseMode.MARKDOWN)
+
+def forecast(bot, update):
+    """Send a message when the command /weather is issued."""
+    try:
+        r = requests.get('{}&appid={}'.format(FORECAST_BASE_URL, WEATHER_API_KEY))
+        weather = json.loads(r.text)
+    except:
+        update.message.reply_text('Lo siento, ¡desconozco el tiempo atmosférico actual!')
+    else:
+        days = []
+        for i in range(weather['cnt']):
+            date_time_str = weather['list'][i]['dt_txt']
+            date_time = datetime.strptime(date_time_str, '%Y-%m-%d %H:%M:%S')
+            d = date_time.strftime("%d")
+            if(d not in days):
+                days.append(d)
+        keyboard = [[]]
+
+        for x in days:
+            print(x)
+            keyboard_button = telegram.InlineKeyboardButton("dia: {0}".format(days(x)), callback_data=days(x) )
+            keyboard[0].append(keyboard_button)
+		
+        reply_markup = telegram.InlineKeyboardMarkup(keyboard)
+        update.message.reply_text("Indicame que dia quieres: {0} - {1}".format([days[i] for i in (0, -1)][0] , [days[i] for i in (0, -1)][-1]) , reply_markup=reply_markup)
+        
+            
+             

--- a/commands.py
+++ b/commands.py
@@ -227,15 +227,22 @@ def forecast(bot, update):
             d = date_time.strftime("%d")
             if(d not in days):
                 days.append(d)
-        keyboard = [[]]
+        keyboard = []
+        keyboard_inside = []
 
         for x in days:
             print(x)
-            keyboard_button = telegram.InlineKeyboardButton("dia: {0}".format(days(x)), callback_data=days(x) )
-            keyboard[0].append(keyboard_button)
-		
+            keyboard_button = telegram.InlineKeyboardButton("dia: {0}".format(x), callback_data=x )
+            keyboard_inside.append(keyboard_button)
+        
+        keyboard.append(keyboard_inside)
         reply_markup = telegram.InlineKeyboardMarkup(keyboard)
         update.message.reply_text("Indicame que dia quieres: {0} - {1}".format([days[i] for i in (0, -1)][0] , [days[i] for i in (0, -1)][-1]) , reply_markup=reply_markup)
         
+
+def forecast_response(bot, update):
+    query = update.callback_query
+    print(query)
+    query.message.reply_text("selected option: {}".format(query.data))
             
              

--- a/config.py
+++ b/config.py
@@ -4,3 +4,4 @@ CO_POLLUTION_BASE_URL = 'http://api.openweathermap.org/pollution/v1/co/40.44,3.7
 O3_POLLUTION_BASE_URL = 'http://api.openweathermap.org/pollution/v1/o3/40.44,3.70/current.json'
 SO2_POLLUTION_BASE_URL = 'http://api.openweathermap.org/pollution/v1/so2/40.44,3.70/current.json'
 NO2_POLLUTION_BASE_URL = 'http://api.openweathermap.org/pollution/v1/no2/40.44,3.70/current.json'
+FORECAST_BASE_URL = 'http://api.openweathermap.org/data/2.5/forecast?lat=40.4474304&lon=-3.7008608'

--- a/koe.py
+++ b/koe.py
@@ -32,9 +32,9 @@ def main():
     updater.dispatcher.add_handler(CommandHandler('calendar', commands.calendar))
     updater.dispatcher.add_handler(CommandHandler('social', commands.social))
     updater.dispatcher.add_handler(CommandHandler('learn', commands.learn))
-    f = commands.forecast()
-    updater.dispatcher.add_handler(CommandHandler('forecast', f.forecast))
-    updater.dispatcher.add_handler(CallbackQueryHandler(f.forecast_response)) #this is for the bot to notice wich forecast button was pressed
+    forecast = commands.forecast()
+    updater.dispatcher.add_handler(CommandHandler('forecast', forecast.forecast))
+    updater.dispatcher.add_handler(CallbackQueryHandler(forecast.forecast_response)) #this is for the bot to notice wich forecast button was pressed
 
     # log all errors
     updater.dispatcher.add_error_handler(error)

--- a/koe.py
+++ b/koe.py
@@ -9,8 +9,8 @@ import commands
 from logger import logger
 
 # Configuration
-BOTNAME = 'KoeBot'
-TOKEN = os.environ['KOE_TOKEN']
+BOTNAME = 'experiment'
+TOKEN = '682028880:AAFSJjYfITyFUOAGqQVlYvCvUATJFgCd2os'
 
 def error(bot, update, error):
     """Log Errors caused by Updates."""
@@ -32,6 +32,7 @@ def main():
     updater.dispatcher.add_handler(CommandHandler('calendar', commands.calendar))
     updater.dispatcher.add_handler(CommandHandler('social', commands.social))
     updater.dispatcher.add_handler(CommandHandler('learn', commands.learn))
+    updater.dispatcher.add_handler(CommandHandler('forecast', commands.forecast))
 
     # log all errors
     updater.dispatcher.add_error_handler(error)

--- a/koe.py
+++ b/koe.py
@@ -3,7 +3,7 @@
 
 """ SciDataUCM's Telegram bot """
 
-from telegram.ext import Updater, CommandHandler, MessageHandler, Filters
+from telegram.ext import Updater, CommandHandler, MessageHandler, Filters, CallbackQueryHandler
 import os
 import commands
 from logger import logger
@@ -33,6 +33,7 @@ def main():
     updater.dispatcher.add_handler(CommandHandler('social', commands.social))
     updater.dispatcher.add_handler(CommandHandler('learn', commands.learn))
     updater.dispatcher.add_handler(CommandHandler('forecast', commands.forecast))
+    updater.dispatcher.add_handler(CallbackQueryHandler(commands.forecast_response)) #this is for the bot to notice wich forecast button was pressed
 
     # log all errors
     updater.dispatcher.add_error_handler(error)

--- a/koe.py
+++ b/koe.py
@@ -32,8 +32,9 @@ def main():
     updater.dispatcher.add_handler(CommandHandler('calendar', commands.calendar))
     updater.dispatcher.add_handler(CommandHandler('social', commands.social))
     updater.dispatcher.add_handler(CommandHandler('learn', commands.learn))
-    updater.dispatcher.add_handler(CommandHandler('forecast', commands.forecast))
-    updater.dispatcher.add_handler(CallbackQueryHandler(commands.forecast_response)) #this is for the bot to notice wich forecast button was pressed
+    f = commands.forecast()
+    updater.dispatcher.add_handler(CommandHandler('forecast', f.forecast))
+    updater.dispatcher.add_handler(CallbackQueryHandler(f.forecast_response)) #this is for the bot to notice wich forecast button was pressed
 
     # log all errors
     updater.dispatcher.add_error_handler(error)


### PR DESCRIPTION
## Forecast command ##

Due to the success of the /weather command, here comes the /forecast command

What does it do?:  

Show the forecast for a specified day  

How is this dark magic possible?:

1. Query the forecast service in the open weather map api
2. Send a message with the possible days, displayed in an inline keyboard (see telegram api reference)
3. Once a day has been selected, returns the forecast for the several different hours of that day! ANd with emojis!

What substantial code changes were necessary?? (THIS SERVES AS A SUMMARY, FOR DETAIL CHECK THE WHOLE PULL REQUEST ):

1. New forecast class (contains three methods)
    * methid 1: forecast: query the api and retrieve the possible days, it also triggers the inline keyboard display
    * method 2: forecast_reply: handle the request of previous function and send the corresponding forecast information based on the day that was selected
    * method 3: getEmojis: method to get the emojis depending on the weather id. This works with unicode codes. Credit to: https://github.com/mustafababil/Telegram-Weather-Bot/blob/master/responseController.py#L11
2.  1 new command added and one new callback query handler
3. New dependencies:   
   ```
   from telegram.ext import CallbackQueryHandler (koe.py)
   ```   
   ```
   from datetime import datetime (commands.py)
   ```   
   these didnt need actual pip installation on my machine, but double check 
   I havent changed any of the previous code